### PR TITLE
Dietnerf deprecated scikit-image code fix and unnecessary Tensorboard

### DIFF
--- a/DietNeRF-pytorch/dietnerf/run_nerf_helpers.py
+++ b/DietNeRF-pytorch/dietnerf/run_nerf_helpers.py
@@ -3,7 +3,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from lpips import LPIPS
-from skimage.measure import compare_psnr, compare_ssim
+from skimage.metrics import structural_similarity as compare_ssim
+from skimage.metrics import peak_signal_noise_ratio as compare_psnr
 
 # Misc
 img2mse = lambda x, y : torch.mean((x - y) ** 2)

--- a/DietNeRF-pytorch/dietnerf/run_nerf_helpers.py
+++ b/DietNeRF-pytorch/dietnerf/run_nerf_helpers.py
@@ -21,10 +21,10 @@ def get_perceptual_metrics(rgbs, gts, lpips_batch_size=8, device='cuda'):
 
     # From pixelNeRF https://github.com/sxyu/pixel-nerf/blob/2929708e90b246dbd0329ce2a128ef381bd8c25d/eval/calc_metrics.py#L188
     global lpips_vgg
-    ssim = [compare_ssim(rgb, gt, multichannel=True, data_range=1) for rgb, gt in zip(rgbs, gts)]
-    ssim = np.mean(ssim)
+    ssim = [compare_ssim(rgb, gt, multichannel=True, data_range=1, channel_axis=2) for rgb, gt in zip(rgbs, gts)]
+    ssim = np.mean(ssim).astype(np.float64)
     psnr = [compare_psnr(rgb, gt, data_range=1) for rgb, gt in zip(rgbs, gts)]
-    psnr = np.mean(psnr)
+    psnr = np.mean(psnr).astype(np.float64)
 
     # From pixelNeRF https://github.com/sxyu/pixel-nerf/blob/2929708e90b246dbd0329ce2a128ef381bd8c25d/eval/calc_metrics.py#L238
     if lpips_vgg is None:

--- a/DietNeRF-pytorch/requirements.txt
+++ b/DietNeRF-pytorch/requirements.txt
@@ -3,9 +3,8 @@ torchvision>=0.2.1
 imageio
 imageio-ffmpeg
 matplotlib
-numpy
+numpy<=2.0.0
 configargparse
-tensorboard==1.14.0
 tqdm
 opencv-python
 ftfy
@@ -14,6 +13,6 @@ regex
 timm
 fire
 lpips
-scikit-image>=0.12.0,<0.18
+scikit-image>0.17,<0.25.0
 gdown
 ray


### PR DESCRIPTION
### Changes in DietNeRF Implementation

- **Removed TensorBoard**:
  - TensorBoard is never used, so it was removed from `requirements.txt`.

- **scikit-image Compatibility**:
  - `scikit-image` is not compatible with newer numpy versions [scikit-image/scikit-image/pull/6637](https://github.com/scikit-image/scikit-image/pull/6637). This requires upgrading `scikit-image` or downgrading `numpy`. I chose to upgrade `scikit-image`.

- **Updated scikit-image Functions**:
  - `scikit-image`'s `measures.compare_ssim` and `measures.compare_psnr` were moved to `metrics.structural_similarity` and `metrics.peak_signal_noise_ratio` [scikit-image/scikit-image/issues/3567#issuecomment-858520057](https://github.com/scikit-image/scikit-image/issues/3567#issuecomment-858520057).

- **Type Conversion for JSON Compatibility**:
  - The returned types created conflicts with JSON, so they were converted from `np.float32` to `np.float64`.

- **Compatibility Confirmation**:
  - This code works with `numpy 2.0.0` and `scikit-image 0.24.0`.

---

By upgrading `scikit-image` and adjusting the function calls and types, the implementation is now compatible with the latest versions of the required libraries.
